### PR TITLE
Commented out crashReporter.start() in main.development.js

### DIFF
--- a/main.development.js
+++ b/main.development.js
@@ -4,7 +4,7 @@ let menu;
 let template;
 let mainWindow = null;
 
-crashReporter.start();
+// crashReporter.start();
 
 if (process.env.NODE_ENV === 'development') {
   require('electron-debug')();


### PR DESCRIPTION
Otherwise an error gets thrown b/c crashReporter requires values we aren't currently providing. But even if we were to add them there wouldn't be much point b/c crash-reporter requires a server to send crash reports to, and we don't have one!